### PR TITLE
chore: set "private": false in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@rdlabo/ionic-theme-md3",
+  "private": false,
   "version": "1.1.0",
   "description": "Material Design 3 Theme for Ionic Framework",
   "main": "./dist/index.js",


### PR DESCRIPTION
Set `"private": false` in `package.json` to reflect that this repository is **public** on GitHub.