### PR TITLE
feat(list): support structured two-line items

### DIFF
--- a/demo/src/app/index/pages/item-list/item-list.page.html
+++ b/demo/src/app/index/pages/item-list/item-list.page.html
@@ -20,6 +20,7 @@
       </ion-item>
     </ion-item-group>
   </ion-list>
+
   <ion-list [inset]="true">
     <ion-list-header><ion-label>Inset List</ion-label></ion-list-header>
     <ion-item-group>
@@ -30,6 +31,23 @@
         <ion-label>
           Multi-line text that should wrap when it is too long to fit on one line. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
         </ion-label>
+      </ion-item>
+    </ion-item-group>
+    <ion-note>Note additional information.</ion-note>
+  </ion-list>
+
+  <ion-list [inset]="true">
+    <ion-list-header><ion-label>Inset List 2 Lines</ion-label></ion-list-header>
+    <ion-item-group>
+      <ion-item>
+        <ion-label>Basic Item</ion-label>
+        <ion-note>Basic Item note</ion-note>
+      </ion-item>
+      <ion-item>
+        <ion-label>
+          Multi-line text that should wrap when it is too long to fit on one line. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+        </ion-label>
+        <ion-note>Multi-line note</ion-note>
       </ion-item>
     </ion-item-group>
     <ion-note>Note additional information.</ion-note>

--- a/demo/src/app/settings/settings-page.component.html
+++ b/demo/src/app/settings/settings-page.component.html
@@ -29,7 +29,8 @@
       <ion-item></ion-item>
     </ion-item-group>
   </ion-list>
-  <ion-list [inset]="true">
+  <ion-list [inset]="true" class="support-ios-structured">
+    <ion-list-header><ion-label>Support ios26 structured</ion-label></ion-list-header>
     <ion-item-group>
       <ion-item>
         <ion-icon name="airplane" slot="start" style="background: linear-gradient(#f8b250, #f79407)"></ion-icon>
@@ -38,22 +39,22 @@
       <ion-item [detail]="true">
         <ion-icon name="wifi" slot="start" style="background: linear-gradient(#489bfd, #2b77f4)"></ion-icon>
         <ion-label>WiFi</ion-label>
-        <ion-note>ionic-framework-a</ion-note>
+        <ion-note slot="end">ionic-framework-a</ion-note>
       </ion-item>
       <ion-item [detail]="true">
         <ion-icon name="bluetooth" slot="start" style="background: linear-gradient(#459cfa, #2d7afc)"></ion-icon>
         <ion-label>Bluetooth</ion-label>
-        <ion-note>On</ion-note>
+        <ion-note slot="end">On</ion-note>
       </ion-item>
       <ion-item [detail]="true">
         <ion-icon name="stats-chart" slot="start" style="background: linear-gradient(#6fdc83, #3ec75d)"></ion-icon>
         <ion-label>Cellular</ion-label>
-        <ion-note>Off</ion-note>
+        <ion-note slot="end">Off</ion-note>
       </ion-item>
       <ion-item [detail]="true" [disabled]="true">
         <ion-icon name="unlink" slot="start" style="background: linear-gradient(#6fdc83, #3ec75d)"></ion-icon>
         <ion-label>Personal Hotspot</ion-label>
-        <ion-note>Off</ion-note>
+        <ion-note slot="end">Off</ion-note>
       </ion-item>
       <ion-item [detail]="true">
         <ion-icon name="battery-full" slot="start" style="background: linear-gradient(#6fdc83, #3ec75d)"></ion-icon>
@@ -61,55 +62,18 @@
       </ion-item>
     </ion-item-group>
   </ion-list>
-  <ion-list [inset]="true">
+  <ion-list [inset]="true" class="support-md-structured">
+    <ion-list-header><ion-label>Support md3 structured</ion-label></ion-list-header>
     <ion-item-group>
-      <ion-item [detail]="true">
-        <ion-icon name="cog-outline" slot="start" style="background: linear-gradient(#afafb4, #8e8e93)"></ion-icon>
-        <ion-label>General</ion-label>
+      <ion-item [detail]="false">
+        <ion-icon name="wifi" slot="start" style="background: #459cfa"></ion-icon>
+        <ion-label>Network & internet</ion-label>
+        <ion-note>Mobile, Wi-Fi, hotspot</ion-note>
       </ion-item>
-      <ion-item [detail]="true">
-        <ion-icon name="accessibility" slot="start" style="background: linear-gradient(#43a6ff, #0288ff)"></ion-icon>
-        <ion-label>Accessibility</ion-label>
-      </ion-item>
-      <ion-item [detail]="true">
-        <ion-icon name="log-in-outline" slot="start" style="background: linear-gradient(#43a6ff, #0288ff)"></ion-icon>
-        <ion-label>Action Button</ion-label>
-      </ion-item>
-      <ion-item [detail]="true">
-        <ion-icon name="logo-angular" slot="start" style="background: linear-gradient(#f9a432, #e193fb)"></ion-icon>
-        <ion-label>Apple Intelligence & Siri</ion-label>
-      </ion-item>
-      <ion-item [detail]="true">
-        <ion-icon name="camera" slot="start" style="background: linear-gradient(#afafb4, #8e8e93)"></ion-icon>
-        <ion-label>Camera</ion-label>
-      </ion-item>
-      <ion-item [detail]="true">
-        <ion-icon name="calculator" slot="start" style="background: linear-gradient(#43a6ff, #0288ff)"></ion-icon>
-        <ion-label>Home Screen & App Library</ion-label>
-      </ion-item>
-      <ion-item [detail]="true">
-        <ion-icon name="search-outline" slot="start" style="background: linear-gradient(#afafb4, #8e8e93)"></ion-icon>
-        <ion-label>Search</ion-label>
-      </ion-item>
-      <ion-item [detail]="true">
-        <ion-icon name="snow" slot="start" style="background: var(--ion-text-color, #000)"></ion-icon>
-        <ion-label>StandBy</ion-label>
-      </ion-item>
-    </ion-item-group>
-  </ion-list>
-  <ion-list [inset]="true">
-    <ion-item-group>
-      <ion-item [detail]="true">
-        <ion-icon name="hourglass" slot="start" style="background: linear-gradient(#887dff, #6055f5)"></ion-icon>
-        <ion-label>Screen Time</ion-label>
-      </ion-item>
-    </ion-item-group>
-  </ion-list>
-  <ion-list [inset]="true">
-    <ion-item-group>
-      <ion-item [detail]="true">
-        <ion-icon name="hand-left" slot="start" style="background: linear-gradient(#43a6ff, #0288ff)"></ion-icon>
-        <ion-label>Privacy & Security</ion-label>
+      <ion-item [detail]="false">
+        <ion-icon name="laptop-outline" slot="start" style="background: #459cfa"></ion-icon>
+        <ion-label>Connected devices</ion-label>
+        <ion-note>Bluetooth, pairing</ion-note>
       </ion-item>
     </ion-item-group>
   </ion-list>

--- a/demo/src/app/settings/settings-page.component.scss
+++ b/demo/src/app/settings/settings-page.component.scss
@@ -6,16 +6,28 @@ ion-list.list-inset {
   margin-bottom: 32px;
 }
 
-ion-item > ion-icon[slot='start'] {
-  border-radius: 8px;
-  padding: 4px;
-  margin-right: 14px;
-  color: var(--ion-background-color, #fff);
-  font-size: 1.3rem;
+.support-ios-structured {
+  ion-item > ion-icon[slot='start'] {
+    padding: 4px;
+    margin-right: 14px;
+    border-radius: 8px;
+  }
+}
+
+.support-md-structured {
+  ion-item > ion-icon[slot='start'] {
+    padding: 8px;
+    width: calc(40px - 16px);
+    height: calc(40px - 16px);
+    margin-right: 16px;
+    border-radius: 50%;
+    background: var(--ion-color-light-shade);
+  }
 }
 
 ion-list.user-info {
   margin-top: 0;
+  margin-bottom: 0;
   ion-avatar {
     width: 64px;
     height: 64px;

--- a/demo/src/app/settings/settings-page.component.scss
+++ b/demo/src/app/settings/settings-page.component.scss
@@ -6,9 +6,14 @@ ion-list.list-inset {
   margin-bottom: 32px;
 }
 
+ion-item > ion-icon[slot='start'] {
+  color: var(--ion-background-color, #fff);
+}
+
 .support-ios-structured {
   ion-item > ion-icon[slot='start'] {
     padding: 4px;
+    font-size: 1.3rem;
     margin-right: 14px;
     border-radius: 8px;
   }

--- a/demo/src/app/settings/settings-page.component.ts
+++ b/demo/src/app/settings/settings-page.component.ts
@@ -21,6 +21,7 @@ import {
   IonToolbar,
   Platform,
 } from '@demo/ionic';
+import { IonListHeader, IonText } from '@ionic/angular';
 
 @Component({
   selector: 'app-settings-page',
@@ -45,6 +46,8 @@ import {
     IonNote,
     IonItemGroup,
     IonToggle,
+    IonText,
+    IonListHeader,
   ],
 })
 export class SettingsPage {

--- a/demo/src/app/settings/settings-page.component.ts
+++ b/demo/src/app/settings/settings-page.component.ts
@@ -20,8 +20,9 @@ import {
   IonToggle,
   IonToolbar,
   Platform,
+  IonListHeader,
+  IonText,
 } from '@demo/ionic';
-import { IonListHeader, IonText } from '@ionic/angular';
 
 @Component({
   selector: 'app-settings-page',

--- a/src/styles/components/ion-list.scss
+++ b/src/styles/components/ion-list.scss
@@ -11,6 +11,10 @@ ion-list.md:not(.md3-disabled).list-inset {
   ion-item-group > ion-item {
     --border-color: var(--ion-color-light, #fff);
 
+    ion-note[slot='end'] {
+      font-size: max(14px, 1rem);
+    }
+
     &:not(.item-lines-inset):not(.item-lines-none) {
       --border-radius: 4px;
       --border-width: #{0px 0px 2px 0px};

--- a/src/styles/components/ion-list.scss
+++ b/src/styles/components/ion-list.scss
@@ -6,7 +6,7 @@ ion-list.md:not(.md3-disabled):not(.list-inset) {
 }
 
 ion-list.md:not(.md3-disabled).list-inset {
-  @include theme-list-inset.ion-list-inset();
+  @include theme-list-inset.ion-list-inset(8px);
 
   ion-item-group > ion-item {
     --border-color: var(--ion-color-light, #fff);

--- a/src/styles/utils/theme-list-inset.scss
+++ b/src/styles/utils/theme-list-inset.scss
@@ -64,6 +64,29 @@
     }
 
     ion-item {
+      &:has(> ion-label:not([slot])):has(> ion-note:not([slot])) {
+        &::part(container) {
+          flex-direction: column;
+          justify-content: center;
+          padding-top: 8px;
+          padding-bottom: 8px;
+        }
+        & > ion-label,
+        & > ion-note {
+          width: auto;
+          align-self: flex-start;
+        }
+        & > ion-label {
+          margin: 0;
+          font-size: 1.2rem;
+          transform: translateY(2px);
+        }
+        & > ion-note {
+          font-size: 0.9rem;
+          transform: translateY(-2px);
+        }
+      }
+
       ion-text[slot='end'] {
         padding-left: 8px;
       }

--- a/src/styles/utils/theme-list-inset.scss
+++ b/src/styles/utils/theme-list-inset.scss
@@ -96,6 +96,6 @@
     color: var(--ion-color-medium-tint);
     font-size: 0.9rem;
     display: block;
-    margin: 8px calc(20px + var(--ion-safe-area-right)) 8px calc(20px + var(--ion-safe-area-left));
+    margin: 8px calc(var(--ion-safe-area-right, 0) + 4px) 8px calc(var(--ion-safe-area-left, 0) + 4px);
   }
 }

--- a/src/styles/utils/theme-list-inset.scss
+++ b/src/styles/utils/theme-list-inset.scss
@@ -1,4 +1,4 @@
-@mixin ion-list-inset() {
+@mixin ion-list-inset($note-inset) {
   background: transparent;
 
   ion-list-header {
@@ -119,6 +119,6 @@
     color: var(--ion-color-medium-tint);
     font-size: 0.9rem;
     display: block;
-    margin: 8px calc(var(--ion-safe-area-right, 0) + 4px) 8px calc(var(--ion-safe-area-left, 0) + 4px);
+    margin: 8px calc(var(--ion-safe-area-right, 0) + $note-inset) 8px calc(var(--ion-safe-area-left, 0) + $note-inset);
   }
 }


### PR DESCRIPTION
## Summary

- add structured two-line layouts for inset list items containing an unslotted label and note
- left-align labels and notes while preserving vertically centered item content
- tune typography and spacing for MD3 structured list items
- keep end-slot notes compatible with the iOS-style structured list example
- account for safe-area values in inset-list note margins
- add demo coverage for MD3 and iOS-style structured lists, including wrapped labels

## Verification

- `npm run fmt`
- `npm run lint`
- `npm run build`