### PR TITLE
docs: mention ion item group ESLint rule

### DIFF
--- a/docs/using-ion-item-group.md
+++ b/docs/using-ion-item-group.md
@@ -20,6 +20,10 @@ The examples use framework-neutral Web Component markup. In React or Vue, use th
 
 No wrapper is required for lists that do not use `inset="true"`.
 
+## Checking Angular templates
+
+In Ionic Angular applications, the [`@rdlabo/rules/require-ion-item-group`](https://docs.rdlabo.dev/projects/eslint-plugin-rules/docs/rules/require-ion-item-group) ESLint rule checks that each `ion-item` in an `ion-list` is wrapped by the group component that matches its behavior. The rule is included in the recommended preset and can automatically fix some violations.
+
 ## Why the wrapper is required
 
 The shared structure keeps `ion-list-header` separate from the item surface. This matches the iOS 26 layout while allowing MD3 to style the same markup without platform-specific templates.


### PR DESCRIPTION
## Summary
- document the Angular ESLint rule for grouped Ionic list items
- note its recommended preset and partial autofix support
- link to the portal rule reference

## Checks
- Prettier check
- git diff --check